### PR TITLE
fix: Sanitize Retry-After strings before setHeader

### DIFF
--- a/src/exception/retry-after.ts
+++ b/src/exception/retry-after.ts
@@ -34,7 +34,12 @@ export function formatRetryAfter(value: unknown): string | undefined {
     return Number.isNaN(value.getTime()) ? undefined : value.toUTCString();
   }
   if (typeof value === 'string') {
-    return value.trim() === '' ? undefined : value;
+    const trimmed = value.trim();
+    if (trimmed === '') return undefined;
+    // Node rejects header values containing CTL chars (e.g. CR/LF). Skip rather
+    // than let setHeader throw and break the exception filter.
+    if (/[\x00-\x1F\x7F]/.test(trimmed)) return undefined;
+    return trimmed;
   }
   return undefined;
 }

--- a/src/filter/http-exception.filter.ts
+++ b/src/filter/http-exception.filter.ts
@@ -199,11 +199,16 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const formatted = formatRetryAfter(value);
     if (formatted === undefined) return;
 
-    this.httpAdapterHost.httpAdapter.setHeader(
-      response,
-      'Retry-After',
-      formatted,
-    );
+    try {
+      this.httpAdapterHost.httpAdapter.setHeader(
+        response,
+        'Retry-After',
+        formatted,
+      );
+    } catch {
+      // Invalid header value after formatting — omit Retry-After rather than
+      // crashing the exception filter.
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Sanitize Retry-After strings before setHeader

## Changes

- reject Retry-After strings with control characters
- try/catch around setHeader for Retry-After

Fixes #46


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of retry timing information by trimming valid values and rejecting unsafe content.
  - Prevented invalid or unsupported retry information from being sent in response headers.
  - Ensured failures while setting retry headers no longer interrupt error responses or cause the exception handling process to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->